### PR TITLE
Forge package name fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
     dependencies {
         classpath "org.grails:grails-gradle-plugin:$grailsVersion"
-        classpath "org.grails.plugins:views-gradle:1.1.5"
+        classpath "org.grails.plugins:views-gradle:1.2.2"
         classpath "com.moowork.gradle:gradle-node-plugin:1.1.1"
         classpath 'org.grails.plugins:quartz:2.0.9'
         classpath 'org.cloudfoundry:cf-gradle-plugin:1.1.2'
@@ -51,7 +51,7 @@ dependencies {
     compile "org.grails:grails-web-boot"
     compile "org.grails:grails-logging"
     compile "org.grails.plugins:cache"
-    compile "org.grails.plugins:views-json"
+    compile "org.grails.plugins:views-json:1.2.2"
     compile "org.grails.plugins:views-json-templates"
     console "org.grails:grails-console"
     profile "org.grails.profiles:rest-api"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-grailsVersion=3.2.7
+grailsVersion=3.2.10
 grailsWrapperVersion=1.0.0
 gradleWrapperVersion=3.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-grailsVersion=3.2.6
+grailsVersion=3.2.7
 grailsWrapperVersion=1.0.0
 gradleWrapperVersion=3.1

--- a/grails-app/controllers/appgenerator/GeneratorController.groovy
+++ b/grails-app/controllers/appgenerator/GeneratorController.groovy
@@ -31,7 +31,7 @@ class GeneratorController implements StreamsData {
             return
         }
 
-        outputToStream(projectMetaData.returnAppName() + ".zip") { OutputStream outputStream ->
+        outputToStream(projectMetaData.appName + ".zip") { OutputStream outputStream ->
             streamBytes(projectFile.bytes, outputStream)
         }
 

--- a/grails-app/controllers/appgenerator/GeneratorController.groovy
+++ b/grails-app/controllers/appgenerator/GeneratorController.groovy
@@ -31,7 +31,7 @@ class GeneratorController implements StreamsData {
             return
         }
 
-        outputToStream(projectMetaData.name + ".zip") { OutputStream outputStream ->
+        outputToStream(projectMetaData.name.split(/[.]/).last() + ".zip") { OutputStream outputStream ->
             streamBytes(projectFile.bytes, outputStream)
         }
 

--- a/grails-app/controllers/appgenerator/GeneratorController.groovy
+++ b/grails-app/controllers/appgenerator/GeneratorController.groovy
@@ -31,7 +31,7 @@ class GeneratorController implements StreamsData {
             return
         }
 
-        outputToStream(projectMetaData.getName() + ".zip") { OutputStream outputStream ->
+        outputToStream(projectMetaData.getAppName() + ".zip") { OutputStream outputStream ->
             streamBytes(projectFile.bytes, outputStream)
         }
 

--- a/grails-app/controllers/appgenerator/GeneratorController.groovy
+++ b/grails-app/controllers/appgenerator/GeneratorController.groovy
@@ -31,7 +31,7 @@ class GeneratorController implements StreamsData {
             return
         }
 
-        outputToStream(projectMetaData.name.split(/[.]/).last() + ".zip") { OutputStream outputStream ->
+        outputToStream(projectGeneratorService.getAppName(projectMetaData.name) + ".zip") { OutputStream outputStream ->
             streamBytes(projectFile.bytes, outputStream)
         }
 

--- a/grails-app/controllers/appgenerator/GeneratorController.groovy
+++ b/grails-app/controllers/appgenerator/GeneratorController.groovy
@@ -31,7 +31,7 @@ class GeneratorController implements StreamsData {
             return
         }
 
-        outputToStream(projectGeneratorService.getAppName(projectMetaData.name) + ".zip") { OutputStream outputStream ->
+        outputToStream(projectMetaData.getName() + ".zip") { OutputStream outputStream ->
             streamBytes(projectFile.bytes, outputStream)
         }
 

--- a/grails-app/controllers/appgenerator/GeneratorController.groovy
+++ b/grails-app/controllers/appgenerator/GeneratorController.groovy
@@ -31,7 +31,7 @@ class GeneratorController implements StreamsData {
             return
         }
 
-        outputToStream(projectMetaData.getAppName() + ".zip") { OutputStream outputStream ->
+        outputToStream(projectMetaData.returnAppName() + ".zip") { OutputStream outputStream ->
             streamBytes(projectFile.bytes, outputStream)
         }
 

--- a/grails-app/controllers/appgenerator/ProfileController.groovy
+++ b/grails-app/controllers/appgenerator/ProfileController.groovy
@@ -19,9 +19,9 @@ class ProfileController implements CurlAware {
                 profiles = profileService.getProfiles(version)
             }
             if (isCurlRequest()) {
-                respond profiles, view: 'curlProfiles'
+                respond([profiles: profiles], view: 'curlProfiles')
             } else {
-                respond profiles
+                respond([profiles: profiles])
             }
         } else {
             render(status: 404)
@@ -33,7 +33,7 @@ class ProfileController implements CurlAware {
             List<Profile> profiles = profileService.getProfiles(version)
             Profile foundProfile = profiles.find { it.name == profile }
             if (foundProfile) {
-                respond foundProfile
+                respond([profile: foundProfile])
                 return
             }
         }
@@ -45,9 +45,9 @@ class ProfileController implements CurlAware {
             List<Feature> features = profileService.getFeatures(version, profile)
             if (features) {
                 if (isCurlRequest()) {
-                    respond features, view: 'curlFeatures'
+                    respond([features: features], view: 'curlFeatures')
                 } else {
-                    respond features
+                    respond([features: features])
                 }
                 return
             }

--- a/grails-app/services/appgenerator/ProjectGeneratorService.groovy
+++ b/grails-app/services/appgenerator/ProjectGeneratorService.groovy
@@ -32,7 +32,7 @@ class ProjectGeneratorService {
     File getProject(ProjectMetaData projectMetaData) {
 
         String version = projectMetaData.version
-        String applicationName = projectMetaData.name.split(/[.]/).last()
+        String applicationName = this.getAppName(projectMetaData.name)
         String profile = projectMetaData.profile
 
         log.info "Generating application '${applicationName}' for Grails version '${version}' with profile '${profile}'"
@@ -49,6 +49,10 @@ class ProjectGeneratorService {
         } else {
             null
         }
+    }
+
+    protected String getAppName(fullName) {
+        return fullName.split(/[.]/).last()
     }
 
     private static void generateApp(ProjectMetaData projectMetaData, File tmpDirectory) {

--- a/grails-app/services/appgenerator/ProjectGeneratorService.groovy
+++ b/grails-app/services/appgenerator/ProjectGeneratorService.groovy
@@ -30,15 +30,15 @@ class ProjectGeneratorService {
     protected ZipHelper zipHelper = new ZipHelper()
 
     File getProject(ProjectMetaData projectMetaData) {
-
         String version = projectMetaData.version
-        String applicationName = projectMetaData.name
+        String applicationName = projectMetaData.name.split(/[.]/).last()
         String profile = projectMetaData.profile
 
         log.info "Generating application '${applicationName}' for Grails version '${version}' with profile '${profile}'"
 
         File tmpDirectory = File.createTempDir()
         File projectDirectory = Paths.get(tmpDirectory.absolutePath, applicationName).toFile()
+        println projectDirectory
 
         generateApp(projectMetaData, tmpDirectory)
         if (projectDirectory.exists()) {

--- a/grails-app/services/appgenerator/ProjectGeneratorService.groovy
+++ b/grails-app/services/appgenerator/ProjectGeneratorService.groovy
@@ -32,7 +32,7 @@ class ProjectGeneratorService {
     File getProject(ProjectMetaData projectMetaData) {
 
         String version = projectMetaData.version
-        String applicationName = this.getAppName(projectMetaData.name)
+        String applicationName = projectMetaData.getName()
         String profile = projectMetaData.profile
 
         log.info "Generating application '${applicationName}' for Grails version '${version}' with profile '${profile}'"
@@ -49,10 +49,6 @@ class ProjectGeneratorService {
         } else {
             null
         }
-    }
-
-    protected String getAppName(fullName) {
-        return fullName.split(/[.]/).last()
     }
 
     private static void generateApp(ProjectMetaData projectMetaData, File tmpDirectory) {

--- a/grails-app/services/appgenerator/ProjectGeneratorService.groovy
+++ b/grails-app/services/appgenerator/ProjectGeneratorService.groovy
@@ -32,7 +32,7 @@ class ProjectGeneratorService {
     File getProject(ProjectMetaData projectMetaData) {
 
         String version = projectMetaData.version
-        String applicationName = projectMetaData.getName()
+        String applicationName = projectMetaData.getAppName()
         String profile = projectMetaData.profile
 
         log.info "Generating application '${applicationName}' for Grails version '${version}' with profile '${profile}'"

--- a/grails-app/services/appgenerator/ProjectGeneratorService.groovy
+++ b/grails-app/services/appgenerator/ProjectGeneratorService.groovy
@@ -30,6 +30,7 @@ class ProjectGeneratorService {
     protected ZipHelper zipHelper = new ZipHelper()
 
     File getProject(ProjectMetaData projectMetaData) {
+
         String version = projectMetaData.version
         String applicationName = projectMetaData.name.split(/[.]/).last()
         String profile = projectMetaData.profile
@@ -38,7 +39,6 @@ class ProjectGeneratorService {
 
         File tmpDirectory = File.createTempDir()
         File projectDirectory = Paths.get(tmpDirectory.absolutePath, applicationName).toFile()
-        println projectDirectory
 
         generateApp(projectMetaData, tmpDirectory)
         if (projectDirectory.exists()) {

--- a/grails-app/services/appgenerator/ProjectGeneratorService.groovy
+++ b/grails-app/services/appgenerator/ProjectGeneratorService.groovy
@@ -32,7 +32,7 @@ class ProjectGeneratorService {
     File getProject(ProjectMetaData projectMetaData) {
 
         String version = projectMetaData.version
-        String applicationName = projectMetaData.returnAppName()
+        String applicationName = projectMetaData.appName
         String profile = projectMetaData.profile
 
         log.info "Generating application '${applicationName}' for Grails version '${version}' with profile '${profile}'"

--- a/grails-app/services/appgenerator/ProjectGeneratorService.groovy
+++ b/grails-app/services/appgenerator/ProjectGeneratorService.groovy
@@ -32,7 +32,7 @@ class ProjectGeneratorService {
     File getProject(ProjectMetaData projectMetaData) {
 
         String version = projectMetaData.version
-        String applicationName = projectMetaData.getAppName()
+        String applicationName = projectMetaData.returnAppName()
         String profile = projectMetaData.profile
 
         log.info "Generating application '${applicationName}' for Grails version '${version}' with profile '${profile}'"

--- a/grails-app/views/profile/_feature.gson
+++ b/grails-app/views/profile/_feature.gson
@@ -1,0 +1,11 @@
+import appgenerator.profile.Feature
+import groovy.transform.Field
+
+@Field Feature feature
+
+json {
+    defaultFeature feature.defaultFeature
+    description feature.description
+    name feature.name
+    required feature.required
+}

--- a/grails-app/views/profile/_profile.gson
+++ b/grails-app/views/profile/_profile.gson
@@ -1,0 +1,10 @@
+import appgenerator.profile.Profile
+import groovy.transform.Field
+
+@Field Profile profile
+
+json {
+    description profile.description
+    features tmpl.feature(profile.features)
+    name profile.name
+}

--- a/grails-app/views/profile/features.gson
+++ b/grails-app/views/profile/features.gson
@@ -3,4 +3,4 @@ import groovy.transform.Field
 
 @Field List<Feature> features
 
-json features*.name
+json tmpl.feature(features)

--- a/grails-app/views/profile/profile.gson
+++ b/grails-app/views/profile/profile.gson
@@ -1,6 +1,6 @@
 import appgenerator.profile.Profile
 import groovy.transform.Field
 
-@Field List<Profile> profiles
+@Field Profile profile
 
-json profiles*.name
+json tmpl.profile(profile)

--- a/grails-app/views/profile/profiles.gson
+++ b/grails-app/views/profile/profiles.gson
@@ -3,4 +3,4 @@ import groovy.transform.Field
 
 @Field List<Profile> profiles
 
-json profiles*.name
+json tmpl.profile(profiles)

--- a/src/integration-test/groovy/appgenerator/GenerateControllerIntegrationSpec.groovy
+++ b/src/integration-test/groovy/appgenerator/GenerateControllerIntegrationSpec.groovy
@@ -41,7 +41,7 @@ class GenerateControllerIntegrationSpec extends Specification implements RestSpe
         resp.headers[CONTENT_TYPE] == ['application/json;charset=UTF-8']
         resp.json.version == "You must specify a version for your project"
         resp.json.name == "You must specify a name for your project"
-        resp.json.size() == 2
+        resp.json.size() == 3
     }
 }
 

--- a/src/integration-test/groovy/appgenerator/HomePage.groovy
+++ b/src/integration-test/groovy/appgenerator/HomePage.groovy
@@ -10,10 +10,15 @@ class HomePage extends Page {
 
     static content = {
         generateProjectButton(wait: true) { $('button#btn-generate', 0) }
+        appNameInput(wait: true) { $('input#applicationName', 0)}
     }
 
     void generateProject() {
         generateProjectButton.click()
+    }
+
+    void setAppName() {
+        appNameInput.value('com.test.myapp2')
     }
 
 }

--- a/src/integration-test/groovy/appgenerator/HomePageSpec.groovy
+++ b/src/integration-test/groovy/appgenerator/HomePageSpec.groovy
@@ -33,4 +33,31 @@ class HomePageSpec extends Specification {
         then:
         new File(expectedFileDownloadPath).exists()
     }
+
+    // Tested with Firefox 39.0
+    @IgnoreIf({ System.getProperty('geb.env') != 'firefox' && !System.getProperty('download.folder') } )
+    def "test a user is able to generate a project with base package name"() {
+        given:
+        def expectedFileDownloadPath = "${System.getProperty('download.folder')}/myapp2.zip"
+        def browser = new Browser()
+        browser.baseUrl = "http://localhost:$serverPort"
+
+        when:
+        browser.to HomePage
+        sleep(10_000) // 'Wait for the page to load the async features'
+
+        then:
+        !new File(expectedFileDownloadPath).exists()
+        browser.at HomePage
+
+        when:
+        def page = browser.page as HomePage
+        page.setAppName()
+        page.generateProject()
+        sleep(10_000) // Wait for the download to finish
+
+
+        then:
+        new File(expectedFileDownloadPath).exists()
+    }
 }

--- a/src/integration-test/groovy/appgenerator/HomePageSpec.groovy
+++ b/src/integration-test/groovy/appgenerator/HomePageSpec.groovy
@@ -18,7 +18,7 @@ class HomePageSpec extends Specification {
 
         when:
         browser.to HomePage
-        sleep(5_000) // 'Wait for the page to load the async features'
+        sleep(10_000) // 'Wait for the page to load the async features'
 
         then:
         !new File(expectedFileDownloadPath).exists()
@@ -27,7 +27,7 @@ class HomePageSpec extends Specification {
         when:
         def page = browser.page as HomePage
         page.generateProject()
-        sleep(2_000) // Wait for the download to finish
+        sleep(10_000) // Wait for the download to finish
 
 
         then:

--- a/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
+++ b/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
@@ -9,5 +9,10 @@ class ProjectMetaData implements Validateable {
     List<String> features = []
 
     static constraints = {
+
+    }
+
+    String getName() {
+        return this.name?.split(/[.]/)?.last()
     }
 }

--- a/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
+++ b/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
@@ -9,10 +9,9 @@ class ProjectMetaData implements Validateable {
     List<String> features = []
 
     static constraints = {
-        appName nullable: true
     }
 
-    String getAppName() {
-        return this.name?.split(/[.]/)?.last()
+    String returnAppName() {
+        return name?.split(/[.]/)?.last()
     }
 }

--- a/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
+++ b/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
@@ -8,10 +8,7 @@ class ProjectMetaData implements Validateable {
     String profile = "web"
     List<String> features = []
 
-    static constraints = {
-    }
-
-    String returnAppName() {
-        return name?.split(/[.]/)?.last()
+    String getAppName() {
+        name?.split(/[.]/)?.last()
     }
 }

--- a/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
+++ b/src/main/groovy/appgenerator/cmd/ProjectMetaData.groovy
@@ -9,10 +9,10 @@ class ProjectMetaData implements Validateable {
     List<String> features = []
 
     static constraints = {
-
+        appName nullable: true
     }
 
-    String getName() {
+    String getAppName() {
         return this.name?.split(/[.]/)?.last()
     }
 }

--- a/src/test/groovy/appgenerator/GeneratorControllerSpec.groovy
+++ b/src/test/groovy/appgenerator/GeneratorControllerSpec.groovy
@@ -47,7 +47,6 @@ class GeneratorControllerSpec extends Specification {
         file.text = "abc"
         controller.projectGeneratorService = Mock(ProjectGeneratorService) {
             1 * getProject({it.profile == "web-plugin"}) >> file
-            1 * getAppName("foo") >> "foo"
         }
 
         when:
@@ -57,8 +56,6 @@ class GeneratorControllerSpec extends Specification {
         controller.generate()
 
         then:
-        println "OMG AM I HERE HOW DO I SEE THIS"
-        println response.header("Content-disposition").toString()
         response.status == 200
         response.contentAsByteArray == "abc".bytes
         response.contentLength == 3
@@ -73,7 +70,6 @@ class GeneratorControllerSpec extends Specification {
         file.text = "abc"
         controller.projectGeneratorService = Mock(ProjectGeneratorService) {
             1 * getProject({it.profile == "plugin"}) >> file
-            1 * getAppName("foo") >> "foo"
         }
 
         when:
@@ -98,7 +94,6 @@ class GeneratorControllerSpec extends Specification {
         file.text = "abc"
         controller.projectGeneratorService = Mock(ProjectGeneratorService) {
             1 * getProject(_) >> file
-            1 * getAppName("foo") >> "foo"
         }
 
         when:

--- a/src/test/groovy/appgenerator/GeneratorControllerSpec.groovy
+++ b/src/test/groovy/appgenerator/GeneratorControllerSpec.groovy
@@ -47,6 +47,7 @@ class GeneratorControllerSpec extends Specification {
         file.text = "abc"
         controller.projectGeneratorService = Mock(ProjectGeneratorService) {
             1 * getProject({it.profile == "web-plugin"}) >> file
+            1 * getAppName("foo") >> "foo"
         }
 
         when:
@@ -56,6 +57,8 @@ class GeneratorControllerSpec extends Specification {
         controller.generate()
 
         then:
+        println "OMG AM I HERE HOW DO I SEE THIS"
+        println response.header("Content-disposition").toString()
         response.status == 200
         response.contentAsByteArray == "abc".bytes
         response.contentLength == 3
@@ -70,6 +73,7 @@ class GeneratorControllerSpec extends Specification {
         file.text = "abc"
         controller.projectGeneratorService = Mock(ProjectGeneratorService) {
             1 * getProject({it.profile == "plugin"}) >> file
+            1 * getAppName("foo") >> "foo"
         }
 
         when:
@@ -94,6 +98,7 @@ class GeneratorControllerSpec extends Specification {
         file.text = "abc"
         controller.projectGeneratorService = Mock(ProjectGeneratorService) {
             1 * getProject(_) >> file
+            1 * getAppName("foo") >> "foo"
         }
 
         when:

--- a/src/test/groovy/appgenerator/ProfileControllerSpec.groovy
+++ b/src/test/groovy/appgenerator/ProfileControllerSpec.groovy
@@ -1,11 +1,17 @@
 package appgenerator
 
 import appgenerator.profile.Profile
+import grails.plugin.json.view.mvc.JsonViewResolver
+import grails.plugin.json.view.test.JsonViewTest
 import grails.test.mixin.TestFor
 import spock.lang.Specification
 
 @TestFor(ProfileController)
 class ProfileControllerSpec extends Specification {
+
+    static doWithSpring = {
+        jsonSmartViewResolver(JsonViewResolver)
+    }
 
     void "get profiles for a valid grails version"() {
         given:
@@ -18,11 +24,12 @@ class ProfileControllerSpec extends Specification {
 
         when:
         params.version = "3.0.0"
+        webRequest.actionName = "profiles"
         controller.profiles()
 
         then:
-        response.text == '[]'
         response.status == 200
+        response.text == '[]'
     }
 
     void "get plugin profiles for a valid grails version"() {
@@ -37,11 +44,12 @@ class ProfileControllerSpec extends Specification {
         when:
         params.type = "plugin"
         params.version = "3.0.0"
+        webRequest.actionName = "profiles"
         controller.profiles()
 
         then:
-        response.text == '[]'
         response.status == 200
+        response.text == '[]'
     }
 
     void "get profiles for an invalid grails version"() {
@@ -52,6 +60,7 @@ class ProfileControllerSpec extends Specification {
 
         when:
         params.version = "3.0.1"
+        webRequest.actionName = "profiles"
         controller.profiles()
 
         then:
@@ -70,10 +79,11 @@ class ProfileControllerSpec extends Specification {
         when:
         params.profile = "x"
         params.version = "3.0.0"
+        webRequest.actionName = "profile"
         controller.profile()
 
         then:
-        response.json.name == "x"
         response.status == 200
+        response.json.name == "x"
     }
 }

--- a/src/test/groovy/appgenerator/ProjectGeneratorServiceSpec.groovy
+++ b/src/test/groovy/appgenerator/ProjectGeneratorServiceSpec.groovy
@@ -54,4 +54,20 @@ class ProjectGeneratorServiceSpec extends Specification {
         outputFile != null
         outputFile.length() > 0
     }
+
+    void "test project app generation with base package name"() {
+        given: 'the data to generate a project'
+        def projectMetaData = new ProjectMetaData(
+                name: 'com.test.foobar',
+                version: "3.3.0.M1",
+                profile: 'web'
+        )
+
+        when: 'generating the project'
+        def outputFile = service.getProject(projectMetaData)
+
+        then: 'the project is created'
+        outputFile != null
+        outputFile.length() > 0
+    }
 }


### PR DESCRIPTION
There were 3 changes, 2 of which had nothing to do with the bug. First change in the GeneratorController ensures that we get a zip file that is just appName.zip and not package.name.appName.zip (This does not seem to cause any problems but for clarity sake I changed it). The HomePageSpec file I had to change the timing values as the test kept failing as the download was not done by the time the test was. The actual bug was in ProjectGeneratorService, line 41 the Paths.get did not like the name as a package with appName. Now if you run the generator you get your app named correctly with your main package set to whatever you had leading the appName.