### PR TITLE
Remove integrationTest group configuration

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,10 +140,6 @@ assets {
     jarTaskName = "bootWar"
 }
 
-integrationTest {
-    group 'verification'
-}
-
 configurations.all {
     resolutionStrategy.eachDependency { details ->
         if(details.requested.group == 'org.codehaus.groovy' && details.requested.name.startsWith('groovy')) {


### PR DESCRIPTION
The task defaults to "verificaton" at https://github.com/grails/grails-core/blob/97f6f05e68b73c06f73ca81b798bd6ed25914bb6/grails-gradle-plugin/src/main/groovy/org/grails/gradle/plugin/core/IntegrationTestGradlePlugin.groovy#L69 and we don't explicitly configure any of the other Gradle tasks this way.