### PR TITLE
Add endpoint 'pluginData' 

### DIFF
--- a/grails-app/controllers/appgenerator/UrlMappings.groovy
+++ b/grails-app/controllers/appgenerator/UrlMappings.groovy
@@ -7,6 +7,7 @@ class UrlMappings {
         "/validate"(controller: 'generator', action: 'validate')
         "/$name(.zip)"(controller: 'generator', action: 'generateDefault')
         "/appData"(controller: 'versions', action: 'appData')
+        "/pluginData"(controller: 'versions', action: 'pluginData')
         "/versions"(controller: 'versions', action: 'grailsVersions')
         "/$version/profiles"(controller: 'profile', action: 'profiles')
         "/$version/$profile/features"(controller: 'profile', action: 'features')

--- a/grails-app/controllers/appgenerator/VersionsController.groovy
+++ b/grails-app/controllers/appgenerator/VersionsController.groovy
@@ -22,4 +22,10 @@ class VersionsController {
             [version: it, profiles: profileService.getProfiles(it)]
         }])
     }
+
+    def pluginData() {
+        respond([pluginData: versionService.supportedVersions.collect {
+            [version: it, profiles: profileService.getPluginProfiles(it)]
+        }])
+    }
 }

--- a/grails-app/views/versions/pluginData.gson
+++ b/grails-app/views/versions/pluginData.gson
@@ -1,0 +1,8 @@
+import groovy.transform.Field
+
+@Field List<Map> pluginData
+
+json(pluginData) { Map m ->
+    version m.version
+    profiles tmpl."/profile/profile"(m.profiles)
+}

--- a/src/test/groovy/appgenerator/VersionsControllerSpec.groovy
+++ b/src/test/groovy/appgenerator/VersionsControllerSpec.groovy
@@ -52,4 +52,28 @@ class VersionsControllerSpec extends Specification implements ControllerUnitTest
         response.json[1].version == 'b'
         response.json[1].profiles.size() == 1
     }
+
+    void "test pluginData"() {
+        given:
+        controller.versionService = Mock(VersionService) {
+            1 * getSupportedVersions() >> ["a", "b"]
+        }
+        def profile1 = new Profile()
+        def profile2 = new Profile()
+        controller.profileService = Mock(ProfileService) {
+            1 * getProfiles("a") >> [profile1]
+            1 * getProfiles("b") >> [profile2]
+        }
+
+        when:
+        webRequest.actionName = "pluginData"
+        controller.pluginData()
+        render()
+
+        then:
+        response.json[0].version == 'a'
+        response.json[0].profiles.size() == 1
+        response.json[1].version == 'b'
+        response.json[1].profiles.size() == 1
+    }
 }

--- a/src/test/groovy/appgenerator/VersionsControllerSpec.groovy
+++ b/src/test/groovy/appgenerator/VersionsControllerSpec.groovy
@@ -61,8 +61,8 @@ class VersionsControllerSpec extends Specification implements ControllerUnitTest
         def profile1 = new Profile()
         def profile2 = new Profile()
         controller.profileService = Mock(ProfileService) {
-            1 * getProfiles("a") >> [profile1]
-            1 * getProfiles("b") >> [profile2]
+            1 * getPluginProfiles("a") >> [profile1]
+            1 * getPluginProfiles("b") >> [profile2]
         }
 
         when:


### PR DESCRIPTION
Hello.
As you might know, we have our own generator for Grails project in IntelliJ IDEA. It provides a frontend for start.grals.org right in the IDE. 
We use the endpoint `start.grails.org/appData` for retrieving a list of available versions. This endpoint gives us only applications, but not plugins. This PR aims to exhibit plugin data in an analogous endpoint.
Thanks in advance for your attention.